### PR TITLE
Adding support for SendGrid email validation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,43 @@
 
 [![Master Branch Build Status](https://img.shields.io/travis/coldbox-modules/sendgrid-sdk/master.svg?style=flat-square&label=master)](https://travis-ci.org/coldbox-modules/sendgrid-sdk)
 
-## An API for interacting with SendGrid, including sending emails and receiving webhooks
+## An API for interacting with SendGrid, including sending emails, validating email addresses, and receiving webhooks
+
+### Email Validation
+
+Leverage the SendGrid API to validate email addresses.  SendGrid will provide
+a validation result, score, and test results to help you determine the validity
+of an email address.
+
+#### Setup
+
+Configure your SendGrid API key credentials in the `config/ColdBox.cfc` file.
+
+Note: SendGrid uses a Bearer API token header for authentication with their API.
+The SendGrid API Keys can have different permissions granted and email address
+validation is typically seperate from all other permission sets.
+
+
+```
+moduleSettings = {
+    "sendgrid-sdk" = {
+        emailValidationAPIKey = ""
+    }
+};
+```
+
+#### Methods
+
+##### validate
+
+Validate the provided email address. Returns a configured `HyperRequest` instance.
+
+| Name           | Type          | Required? | Default | Description                                                                      |
+| -------------- | ------------- | --------- | ------- | -------------------------------------------------------------------------------- |
+| email          | String        | `true`    |         | The email address to validate                                                    |
+| source         | String        | `false`   |         | An optional text string that identifies the source of the email address          |
+
+
 
 ### Webhooks
 
@@ -27,7 +63,7 @@ correspond with:
 
 The `interceptData` is the data sent from Sendgrid.
 
-### Basic Authentication
+#### Basic Authentication
 
 SendGrid supports basic authentication when calling your webhook.
 To set this up, provide a `username` and `password` in your `moduleSettings`:

--- a/box.json
+++ b/box.json
@@ -4,16 +4,18 @@
     "slug":"sendgrid-sdk-shell",
     "private":false,
     "dependencies":{
-        "coldbox":"^4.3.0",
-        "workbench":"git+https://github.com/Ortus-Solutions/unified-workbench.git"
+        "coldbox":"^6.6.1+2",
+        "workbench":"git+https://github.com/Ortus-Solutions/unified-workbench.git",
+        "hyper":"^3.6.2"
     },
     "devDependencies":{
         "testbox":"^2.5.0"
     },
     "installPaths":{
-        "coldbox":"coldbox",
+        "coldbox":"coldbox/",
         "testbox":"testbox/",
-        "workbench":"workbench"
+        "workbench":"workbench/",
+        "hyper":"modules/hyper/"
     },
     "testbox":{
         "runner":"http://localhost:49616"

--- a/config/Coldbox.cfc
+++ b/config/Coldbox.cfc
@@ -47,7 +47,8 @@ component{
 		moduleSettings = {
             "sendgrid-sdk" = {
                 "username" = "foo",
-                "password" = "bar"
+                "password" = "bar",
+				"emailValidationAPIKey" = "[YOUR API KEY HERE]"
             }
         };
 
@@ -77,10 +78,7 @@ component{
 		};
 
 		//Register interceptors as an array, we need order
-		interceptors = [
-			//SES
-			{ class="coldbox.system.interceptors.SES" }
-		];
+		interceptors = [];
     }
 
     function getSystemSetting( name, defaultValue ) {

--- a/modules/sendgrid-sdk/ModuleConfig.cfc
+++ b/modules/sendgrid-sdk/ModuleConfig.cfc
@@ -4,6 +4,7 @@ component {
     this.author = "Ortus Solutions";
     this.webUrl = "https://github.com/coldbox-modules/sendgrid-sdk";
     this.entrypoint = "/sendgrid";
+    this.dependencies = [ "hyper" ];
 
     function configure() {
         routes = [ { pattern = "/webhooks", handler = "webhooks", action = "handle" } ];
@@ -24,5 +25,15 @@ component {
             ]
         };
     }
+
+	function onLoad() {
+		binder
+			.map( "SendGridHyperClient@sendgrid-sdk" )
+			.to( "hyper.models.HyperBuilder" )
+			.asSingleton()
+			.initWith(
+				baseURL = "https://api.sendgrid.com"
+			);
+	}
 
 }

--- a/modules/sendgrid-sdk/README.md
+++ b/modules/sendgrid-sdk/README.md
@@ -2,7 +2,44 @@
 
 [![Master Branch Build Status](https://img.shields.io/travis/coldbox-modules/sendgrid-sdk/master.svg?style=flat-square&label=master)](https://travis-ci.org/coldbox-modules/sendgrid-sdk)
 
-## An API for interacting with SendGrid, including sending emails and receiving webhooks
+
+## An API for interacting with SendGrid, including sending emails, validating email addresses, and receiving webhooks
+
+### Email Validation
+
+Leverage the SendGrid API to validate email addresses.  SendGrid will provide
+a validation result, score, and test results to help you determine the validity
+of an email address.
+
+#### Setup
+
+Configure your SendGrid API key credentials in the `config/ColdBox.cfc` file.
+
+Note: SendGrid uses a Bearer API token header for authentication with their API.
+The SendGrid API Keys can have different permissions granted and email address
+validation is typically seperate from all other permission sets.
+
+
+```
+moduleSettings = {
+    "sendgrid-sdk" = {
+        emailValidationAPIKey = ""
+    }
+};
+```
+
+#### Methods
+
+##### validate
+
+Validate the provided email address. Returns a configured `HyperRequest` instance.
+
+| Name           | Type          | Required? | Default | Description                                                                      |
+| -------------- | ------------- | --------- | ------- | -------------------------------------------------------------------------------- |
+| email          | String        | `true`    |         | The email address to validate                                                    |
+| source         | String        | `false`   |         | An optional text string that identifies the source of the email address          |
+
+
 
 ### Webhooks
 

--- a/modules/sendgrid-sdk/box.json
+++ b/modules/sendgrid-sdk/box.json
@@ -12,18 +12,21 @@
   "bugs": "https://github.com/coldbox-modules/sendgrid-sdk/issues",
   "slug": "sendgrid-sdk",
   "shortDescription":
-    "An API for interacting with SendGrid, including sending emails and receiving webhooks",
+    "An API for interacting with SendGrid, including sending emails, validating email addresses, and receiving webhooks",
   "description":
-    "An API for interacting with SendGrid, including sending emails and receiving webhooks",
+    "An API for interacting with SendGrid, including sending emails, validating email addresses, and receiving webhooks",
   "type": "modules",
-  "dependencies": {},
+  "dependencies":{
+    "hyper":"^3.4.0"
+  },
   "devDependencies": {
-    "coldbox": "^4.3.0",
-    "testbox": "^2.4.0+80"
+    "testbox":"^4.5.0+5",
+    "coldbox":"^6.6.1+2"
   },
   "installPaths": {
     "testbox": "testbox",
-    "coldbox": "tests/resources/app/coldbox"
+    "coldbox": "tests/resources/app/coldbox",
+    "hyper":"modules/hyper/"
   },
   "scripts": {
     "postVersion":

--- a/modules/sendgrid-sdk/models/SendGridClient.cfc
+++ b/modules/sendgrid-sdk/models/SendGridClient.cfc
@@ -1,0 +1,49 @@
+/**
+ * Interact with the SendGrid API
+ */
+component singleton accessors="true" {
+
+	/**
+	 * The configured SendGrid API Key for Email Validation
+	 */
+	property name="emailValidationAPIKey" inject="box:setting:emailValidationAPIKey@sendgrid-sdk";
+
+	/**
+	 * A configured HyperBuilder client to use with the SendGrid API. 
+	 * This is handled for you when using as a ColdBox module.
+	 */
+	property name="hyperClient" inject="SendGridHyperClient@sendgrid-sdk";
+
+	/**
+	 * Validate an email address
+	 *
+	 * @email          The email address to validate
+	 * @source	       An optional text string that identifies the source of the email address
+	 *
+	 * @returns        A configured HyperRequest instance.
+	 */
+	function validate( required string email, string source ) {
+
+		var reqBody = { "email": arguments.email };
+		if( structKeyExists( arguments, "source" ) && len( arguments.source ) ){
+			reqBody[ "source" ] = arguments.source;
+		}
+
+		var req = newRequest()
+			.setUrl( "/v3/validations/email" )
+			.setMethod( "POST" )
+			.withHeaders( { "Authorization": "Bearer #emailValidationAPIKey#" } )
+			.setBody( reqBody );
+
+		return req;
+	}
+
+	function newRequest() {
+		return hyperClient.new();
+	}
+
+	function onMissingMethod( missingMethodName, missingMethodArguments ) {
+		return invoke( newRequest(), missingMethodName, missingMethodArguments );
+	}
+
+}

--- a/tests/specs/integration/EmailValidationSpec.cfc
+++ b/tests/specs/integration/EmailValidationSpec.cfc
@@ -1,0 +1,34 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+    function run() {
+        describe( "Validate", function() {
+            beforeEach( function() {
+                variables.sendGridClient = getInstance( "SendGridClient@sendgrid-sdk" );
+            } );
+
+            afterEach( function() {
+                structDelete( variables, "sendGridClient" );
+            } );
+
+            /* 
+             * NOTE: This test suite will only execute once a valid SendGrid API key is 
+             * added to the ColdBox.cfc config file AND the API key has access to the
+             * email validation functionality
+             *
+            it( "can validate an email address", function() {
+                var res = sendGridClient.validate(
+                    email = "info@ortussolutions.com",
+                    source = "test source"
+                ).send();
+
+                expect( res.getStatusCode() ).toBe( 200, "Response should be a 200 Ok" );
+
+                expect( res.json().result.email ).toInclude( "info@ortussolutions.com" );
+                expect( res.json().result.source ).toInclude( "test source" );
+            } );
+            */
+
+        } );
+    }
+
+}


### PR DESCRIPTION
The integration tests for the new email validation functionality require a SendGrid API key be added to the ColdBox.cfc config file to run.  Therefore, they are currently commented out.